### PR TITLE
docs(app-shell): add missing `*shellNoRender`

### DIFF
--- a/guides/app-shell.md
+++ b/guides/app-shell.md
@@ -289,7 +289,7 @@ the page is fully rendered.
   {{title}}
 </md-toolbar>
 <md-spinner *shellRender></md-spinner>
-<h1>App is Fully Rendered</h1>
+<h1 *shellNoRender>App is Fully Rendered</h1>
 ```
 
 Now if we navigate to [localhost:4200/hello] in our browser, the spinner should render when the app shell is displayed,


### PR DESCRIPTION
It's already confusing that it mentioned the `router-outlet` and then just uses an `h1` instead.
It's even more confusing with this typo.