### PR TITLE
chore(parser): use official parse5

### DIFF
--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "2.0.0-rc.0",
     "@angular/router": "2.0.0-rc.0",
     "es6-shim": "^0.35.0",
-    "parse5": "https://github.com/mgechev/parse5",
+    "parse5": "^2.1.5",
     "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
     "systemjs": "0.19.26",

--- a/app-shell/src/app/shell-parser/template-parser/parse5-template-parser.ts
+++ b/app-shell/src/app/shell-parser/template-parser/parse5-template-parser.ts
@@ -1,14 +1,18 @@
 import {ASTNode} from '../ast';
 import {TemplateParser} from './template-parser';
-import * as Parse5 from 'parse5';
+
+var Parser = require('../../../vendor/parse5/lib/parser');
+var Serializer = require('../../../vendor/parse5/lib/serializer');
 
 export class Parse5TemplateParser extends TemplateParser {
   parse(template: string): ASTNode {
-    return Parse5.parse(template);
+    var parser = new Parser();
+    return parser.parse(template);
   }
 
   serialize(node: ASTNode): string {
-    return Parse5.serialize(<any>node);
+    var serializer = new Serializer(node);
+    return serializer.serialize();
   }
 }
 


### PR DESCRIPTION
Uses the official parse5 instead of custom fork. Same bundle size (41K min & gzipped) but very tightly coupled to the angular-cli `dist` directory layout.

@jeffbcross would you take a look?