### PR TITLE
feat(AppShell): add resource inline functionality

### DIFF
--- a/app-shell/src/app/shell-parser/ast/ast-node.ts
+++ b/app-shell/src/app/shell-parser/ast/ast-node.ts
@@ -8,5 +8,6 @@ export interface ASTNode {
   childNodes?: ASTNode[];
   parentNode?: ASTNode;
   nodeName: string;
+  value?: string;
 }
 

--- a/app-shell/src/app/shell-parser/config.ts
+++ b/app-shell/src/app/shell-parser/config.ts
@@ -4,6 +4,7 @@ const SHELL_PARSER_CACHE_NAME = 'mobile-toolkit:app-shell';
 const APP_SHELL_URL = './app_shell.html';
 const NO_RENDER_CSS_SELECTOR = '[shellNoRender]';
 const ROUTE_DEFINITIONS: RouteDefinition[] = [];
+const INLINE_IMAGES: string[] = ['png', 'svg', 'jpg'];
 
 // TODO(mgechev): use if we decide to include @angular/core
 // export const SHELL_PARSER_CONFIG = new OpaqueToken('ShellRuntimeParserConfig');
@@ -13,12 +14,14 @@ export interface ShellParserConfig {
   SHELL_PARSER_CACHE_NAME?: string;
   NO_RENDER_CSS_SELECTOR?: string;
   ROUTE_DEFINITIONS?: RouteDefinition[];
+  INLINE_IMAGES?: string[];
 }
 
 export const SHELL_PARSER_DEFAULT_CONFIG: ShellParserConfig = {
   SHELL_PARSER_CACHE_NAME,
   APP_SHELL_URL,
   NO_RENDER_CSS_SELECTOR,
-  ROUTE_DEFINITIONS
+  ROUTE_DEFINITIONS,
+  INLINE_IMAGES
 };
 

--- a/app-shell/src/app/shell-parser/node-visitor/index.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/index.ts
@@ -1,0 +1,4 @@
+export * from './node-visitor';
+export * from './resource-inline';
+export * from './template-strip-visitor';
+

--- a/app-shell/src/app/shell-parser/node-visitor/node-visitor.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/node-visitor.ts
@@ -1,0 +1,23 @@
+import {ASTNode} from '../ast';
+
+export abstract class NodeVisitor {
+
+  abstract process(node: ASTNode): Promise<ASTNode>;
+
+  visit(currentNode: ASTNode): Promise<ASTNode> {
+    return this.process(currentNode)
+      .then((node: ASTNode) => {
+        if (node) {
+          return Promise
+            .all((node.childNodes || [])
+              .slice()
+              .map(this.visit.bind(this)))
+            .then(() => node);
+        } else {
+          return null;
+        }
+      })
+  }
+
+}
+

--- a/app-shell/src/app/shell-parser/node-visitor/resource-inline/index.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/resource-inline/index.ts
@@ -1,0 +1,4 @@
+export * from './resource-inline-visitor';
+export * from './stylesheet-resource-inline-visitor';
+export * from './inline-style-resource-inline-visitor';
+

--- a/app-shell/src/app/shell-parser/node-visitor/resource-inline/inline-style-resource-inline-visitor.spec.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/resource-inline/inline-style-resource-inline-visitor.spec.ts
@@ -1,0 +1,127 @@
+import {
+  beforeEach,
+  it,
+  describe,
+  expect,
+  inject
+} from '@angular/core/testing';
+
+import {ASTNode} from '../../ast';
+import {MockWorkerScope, MockResponse} from '../../testing';
+import {InlineStyleResourceInlineVisitor} from './';
+
+const createResponseHelper = (body: string, contentType: string) => {
+  const response = new MockResponse(body);
+  response.headers = {
+    get(name: string) {
+      if (name === 'content-type') {
+        return contentType;
+      }
+    }
+  };
+  return response;
+};
+
+describe('ResourceInlineVisitor', () => {
+
+  let simpleNode: ASTNode;
+  let nestedAst: ASTNode;
+  let multiStyles: ASTNode;
+  let jpgInlineVisitor: InlineStyleResourceInlineVisitor;
+  let pngJpgInlineVisitor: InlineStyleResourceInlineVisitor;
+  let scope: MockWorkerScope;
+
+  beforeEach(() => {
+    scope = new MockWorkerScope();
+    jpgInlineVisitor = new InlineStyleResourceInlineVisitor(scope, ['jpg']);
+    pngJpgInlineVisitor = new InlineStyleResourceInlineVisitor(scope, ['png', 'jpg']);
+    simpleNode = {
+      attrs: [{
+        name: 'style',
+        value: 'color: #fff; background-image: url(bar.jpg);'
+      }],
+      nodeName: 'div',
+    };
+    multiStyles = {
+      attrs: [{
+        name: 'style',
+        value: 'color: #fff; background-image: url(bar.jpg);'
+      }, {
+        name: 'style',
+        value: 'color: #fff; background-image: url(baz.jpg);'
+      }],
+      nodeName: 'div',
+    };
+    nestedAst = {
+      nodeName: 'body',
+      attrs: null,
+      childNodes: [
+        {
+          nodeName: 'div',
+          attrs: null,
+          childNodes: [
+            {
+              nodeName: 'p',
+              attrs: null,
+              childNodes: [
+                {
+                  nodeName: 'span',
+                  attrs: [{
+                    name: 'style',
+                    value: 'color: #fff; background-image: url(bar.jpg);'
+                  }],
+                }
+              ]
+            }
+          ]
+        },
+        {
+          nodeName: 'section',
+          attrs: null,
+          childNodes: [
+            {
+              nodeName: 'span',
+              attrs: [{
+                name: 'style',
+                value: 'font-size: 42px; background-image: url(bar.png);'
+              }]
+            }
+          ]
+        }
+      ]
+    };
+  });
+
+  it('should inline assets in style attribute', (done: any) => {
+    scope.mockResponses['bar.jpg'] = createResponseHelper('bar', 'image/jpg');
+    jpgInlineVisitor.visit(simpleNode)
+      .then(() => {
+        expect(simpleNode.attrs[0].value).toBe('color: #fff; background-image: url(data:image/jpg;base64,YgBhAHIA);');
+        done();
+      });
+  });
+
+  it('should work with nested elements', (done: any) => {
+    scope.mockResponses['bar.jpg'] = createResponseHelper('bar', 'image/jpg');
+    scope.mockResponses['bar.png'] = createResponseHelper('bar', 'image/png');
+    pngJpgInlineVisitor.visit(nestedAst)
+      .then(() => {
+        expect(nestedAst.childNodes[0].childNodes[0].childNodes[0].attrs[0].value).toBe('color: #fff; background-image: url(data:image/jpg;base64,YgBhAHIA);');
+        expect(nestedAst.childNodes[1].childNodes[0].attrs[0].value).toBe('font-size: 42px; background-image: url(data:image/png;base64,YgBhAHIA);');
+        done();
+      });
+  });
+
+  it('should always pick the last occurence of the style attribute', (done: any) => {
+    scope.mockResponses['bar.jpg'] = createResponseHelper('bar', 'image/jpg');
+    scope.mockResponses['baz.jpg'] = createResponseHelper('baz', 'image/jpg');
+    jpgInlineVisitor.visit(multiStyles)
+      .then(() => {
+        expect(multiStyles.attrs[0].value).toBe('color: #fff; background-image: url(bar.jpg);');
+        expect(multiStyles.attrs[1].value).toBe('color: #fff; background-image: url(data:image/jpg;base64,YgBhAHoA);');
+        done();
+      });
+  });
+
+});
+

--- a/app-shell/src/app/shell-parser/node-visitor/resource-inline/inline-style-resource-inline-visitor.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/resource-inline/inline-style-resource-inline-visitor.ts
@@ -1,0 +1,24 @@
+import {ASTNode, ASTAttribute} from '../../ast';
+import {ResourceInlineVisitor} from './resource-inline-visitor';
+import {WorkerScope} from '../../context';
+
+const URL_REGEXP = /:\s+url\(['"]?(.*?)['"]?\)/gmi;
+
+export class InlineStyleResourceInlineVisitor extends ResourceInlineVisitor {
+
+  process(node: ASTNode): Promise<ASTNode> {
+    const styleAttr = (node.attrs || [])
+      .filter((a: ASTAttribute) => a.name === 'style')
+      .pop();
+    if (styleAttr) {
+      return this.inlineAssets(styleAttr.value)
+        .then((content: string) => {
+          styleAttr.value = content;
+          return node;
+        });
+    }
+    return Promise.resolve(node);
+  }
+
+}
+

--- a/app-shell/src/app/shell-parser/node-visitor/resource-inline/resource-inline-visitor.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/resource-inline/resource-inline-visitor.ts
@@ -1,0 +1,59 @@
+import {ASTNode} from '../../ast';
+import {NodeVisitor} from '../node-visitor';
+import {WorkerScope} from '../../context';
+
+const URL_REGEXP = /:\s+url\(['"]?(.*?)['"]?\)/gmi;
+
+export abstract class ResourceInlineVisitor extends NodeVisitor {
+
+  constructor(private scope: WorkerScope, private inlineExtensions: string[]) {
+    super();
+  }
+
+  inlineAssets(style: string) {
+    let urls = this.getImagesUrls(style);
+    urls = urls.filter((url: string, idx: number) => urls.indexOf(url) === idx);
+    return this.processInline(urls, style)
+      .then((content: string) => content);
+  }
+
+  protected getImagesUrls(styles: string): string[] {
+    URL_REGEXP.lastIndex = 0;
+    let match: string[];
+    const result: string[] = [];
+    while ((match = URL_REGEXP.exec(styles)) !== null) {
+      const url = match[1];
+      if (this.supportedExtension(url)) {
+        result.push(url);
+      }
+    }
+    return result;
+  }
+
+  private supportedExtension(url: string) {
+    return this.inlineExtensions.some((ext: string) => new RegExp(`${ext}$`).test(url));
+  }
+
+  protected processInline(urls: string[], styles: string): Promise<string> {
+    const processResponse = (response: Response): Promise<string[]> => {
+      if (response && response.ok) {
+        return response.arrayBuffer()
+          .then((arr: ArrayBuffer) => [
+            btoa(String.fromCharCode.apply(null, new Uint8Array(arr))),
+            response.headers.get('content-type')
+          ]);
+      } else {
+        return null;
+      }
+    };
+    return Promise.all(urls.map((url: string) => this.scope.fetch(url).catch(() => null)))
+      .then((responses: any[]) => <any>Promise.all(responses.map(processResponse)))
+      .then((images: string[][]) => {
+        return images.map((img: string[]) => img ? `data:${img[1]};base64,${img[0]}` : null)
+        .reduce((content: string, img: string, idx: number) =>
+          img ? content.replace(new RegExp(urls[idx], 'g'), img) : content, styles);
+      });
+  }
+
+}
+

--- a/app-shell/src/app/shell-parser/node-visitor/resource-inline/stylesheet-resource-inline-visitor.spec.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/resource-inline/stylesheet-resource-inline-visitor.spec.ts
@@ -1,0 +1,200 @@
+import {
+  beforeEach,
+  it,
+  describe,
+  expect,
+  inject
+} from '@angular/core/testing';
+
+import {ASTNode} from '../../ast';
+import {MockWorkerScope, MockResponse} from '../../testing';
+import {StylesheetResourceInlineVisitor} from './';
+
+const createResponseHelper = (body: string, contentType: string) => {
+  const response = new MockResponse(body);
+  response.headers = {
+    get(name: string) {
+      if (name === 'content-type') {
+        return contentType;
+      }
+    }
+  };
+  return response;
+};
+
+describe('ResourceInlineVisitor', () => {
+
+  let astRoot: ASTNode;
+  let nestedAst: ASTNode;
+  let simpleNode: ASTNode;
+  let jpgInlineVisitor: StylesheetResourceInlineVisitor;
+  let pngJpgInlineVisitor: StylesheetResourceInlineVisitor;
+  let scope: MockWorkerScope;
+
+  beforeEach(() => {
+    scope = new MockWorkerScope();
+    jpgInlineVisitor = new StylesheetResourceInlineVisitor(scope, ['jpg']);
+    pngJpgInlineVisitor = new StylesheetResourceInlineVisitor(scope, ['png', 'jpg']);
+    simpleNode = {
+      attrs: null,
+      nodeName: 'style',
+      childNodes: [
+        {
+          nodeName: '#text',
+          attrs: null,
+          value: `
+            .bar {
+              background-image: url(bar.jpg);
+            }
+          `
+        }
+      ]
+    };
+
+    astRoot = {
+      attrs: null,
+      nodeName: 'style',
+      childNodes: [
+        {
+          nodeName: '#text',
+          attrs: null,
+          value: `
+            .bar {
+              background-image: url('bar.jpg');
+              background-color: #ccc;
+            }
+            .baz {
+              background-image: url(bar.jpg);
+            }
+            .baz {
+              background-image: url("foo.png");
+            }
+          `
+        }
+      ]
+    };
+
+    nestedAst = {
+      nodeName: 'body',
+      attrs: null,
+      childNodes: [
+        {
+          nodeName: 'div',
+          attrs: null,
+          childNodes: [
+            {
+              nodeName: 'style',
+              attrs: null,
+              childNodes: [
+                {
+                  nodeName: '#text',
+                  attrs: null,
+                  value: `
+                    bar {
+                      background-image: url('bar.jpg');
+                    }
+                  `
+                }
+              ]
+            }
+          ]
+        },
+        {
+          nodeName: 'style',
+          attrs: null,
+          childNodes: [
+            {
+              nodeName: '#text',
+              attrs: null,
+              value: `
+                baz {
+                  background-image: url(bar.jpg);
+                }
+                foo {
+                  background-image: url('bar.svg');
+                }
+              `
+            }
+          ]
+        }
+      ]
+    };
+  });
+
+  it('should replace image with base64 representation', (done: any) => {
+    scope.mockResponses['bar.jpg'] = createResponseHelper('image', 'image/jpg');
+    jpgInlineVisitor.visit(simpleNode)
+      .then(() => {
+        expect(simpleNode.childNodes[0]).not.toBeFalsy();
+        expect(simpleNode.childNodes[0].value).toBe(
+               `
+            .bar {
+              background-image: url(data:image/jpg;base64,aQBtAGEAZwBlAA==);
+            }
+          `);
+        done();
+      });
+  });
+
+  it('should replace images in multiple styles', (done: any) => {
+    scope.mockResponses['foo.png'] = createResponseHelper('foo', 'image/png');
+    scope.mockResponses['bar.jpg'] = createResponseHelper('bar', 'image/jpg');
+    pngJpgInlineVisitor.visit(astRoot)
+      .then(() => {
+        const styles = astRoot.childNodes[0].value;
+        expect(styles).not.toBeFalsy();
+        expect(styles).toBe(`
+            .bar {
+              background-image: url('data:image/jpg;base64,YgBhAHIA');
+              background-color: #ccc;
+            }
+            .baz {
+              background-image: url(data:image/jpg;base64,YgBhAHIA);
+            }
+            .baz {
+              background-image: url("data:image/png;base64,ZgBvAG8A");
+            }
+          `
+        );
+        done();
+      });
+  });
+
+  it('should handle invalid requests', (done: any) => {
+    jpgInlineVisitor.visit(simpleNode)
+      .then(() => {
+        expect(simpleNode.childNodes[0].value).toBe(
+               `
+            .bar {
+              background-image: url(bar.jpg);
+            }
+          `);
+        done();
+      });
+  });
+
+  it('should work with nested elements', (done: any) => {
+    scope.mockResponses['bar.jpg'] = createResponseHelper('bar', 'image/jpg');
+    pngJpgInlineVisitor.visit(nestedAst)
+      .then(() => {
+        let s1 = nestedAst.childNodes[0].childNodes[0].childNodes[0].value;
+        let s2 = nestedAst.childNodes[1].childNodes[0].value;
+        expect(s1).toBe(`
+                    bar {
+                      background-image: url('data:image/jpg;base64,YgBhAHIA');
+                    }
+                  `);
+        expect(s2).toBe(`
+                baz {
+                  background-image: url(data:image/jpg;base64,YgBhAHIA);
+                }
+                foo {
+                  background-image: url('bar.svg');
+                }
+              `);
+        done();
+      });
+  });
+
+});
+

--- a/app-shell/src/app/shell-parser/node-visitor/resource-inline/stylesheet-resource-inline-visitor.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/resource-inline/stylesheet-resource-inline-visitor.ts
@@ -1,0 +1,22 @@
+import {ASTNode} from '../../ast';
+import {ResourceInlineVisitor} from './resource-inline-visitor';
+import {WorkerScope} from '../../context';
+
+const URL_REGEXP = /:\s+url\(['"]?(.*?)['"]?\)/gmi;
+
+export class StylesheetResourceInlineVisitor extends ResourceInlineVisitor {
+
+  process(node: ASTNode): Promise<ASTNode> {
+    if (node.nodeName.toLowerCase() === 'style') {
+      const styleNode = node.childNodes[0];
+      return this.inlineAssets(styleNode.value)
+        .then((content: string) => {
+          styleNode.value = content;
+          return node;
+        });
+    }
+    return Promise.resolve(node);
+  }
+
+}
+

--- a/app-shell/src/app/shell-parser/node-visitor/template-strip-visitor.spec.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/template-strip-visitor.spec.ts
@@ -1,0 +1,78 @@
+import {
+  beforeEach,
+  it,
+  describe,
+  expect,
+  inject
+} from '@angular/core/testing';
+
+import {ASTNode} from '../ast';
+import {cssNodeMatcherFactory} from '../node-matcher';
+import {MockWorkerScope, MockResponse} from '../testing';
+import {TemplateStripVisitor} from './';
+
+describe('TemplateStripVisitor', () => {
+
+  let astRoot: ASTNode;
+
+  beforeEach(() => {
+    astRoot = {
+      nodeName: 'div',
+      attrs: [],
+      childNodes: []
+    };
+    const div1: ASTNode = { nodeName: 'div', attrs: [{ name: 'class', value: 'foo' }] };
+    const section: ASTNode = {
+      nodeName: 'section',
+      attrs: [],
+      parentNode: astRoot,
+      childNodes: [
+        div1
+      ]
+    };
+    div1.parentNode = section;
+    const span1: ASTNode = { nodeName: 'span', childNodes: [], attrs: [], parentNode: astRoot };
+    const div2: ASTNode = {
+      nodeName: 'div',
+      parentNode: span1,
+      attrs: [{ name: 'class', value: 'foo' }]
+    };
+    span1.childNodes.push(div2);
+    const span2: ASTNode = { nodeName: 'span', attrs: [], parentNode: astRoot }
+    astRoot.childNodes.push(section);
+    astRoot.childNodes.push(span1);
+    astRoot.childNodes.push(span2);
+  });
+
+  it('should strip the root when match', (done: any) => {
+    let stripper = new TemplateStripVisitor(cssNodeMatcherFactory('div'));
+    stripper.visit(astRoot)
+      .then((astNode: ASTNode) => {
+        expect(astNode).toBe(null);
+      });
+    done();
+  });
+
+  it('should strip all nodes matching a selector', (done: any) => {
+    let stripper = new TemplateStripVisitor(cssNodeMatcherFactory('span'));
+    stripper.visit(astRoot)
+      .then((astNode: ASTNode) => {
+        expect(astNode.childNodes.length).toBe(1);
+        done();
+      });
+  });
+
+  it('should strip nodes in different areas of the tree', (done: any) => {
+    let stripper = new TemplateStripVisitor(cssNodeMatcherFactory('.foo'));
+    stripper.visit(astRoot)
+      .then((astNode: ASTNode) => {
+        // div > section > div.foo to be removed
+        expect(astNode.childNodes[0].childNodes.length).toBe(0);
+        // div > span > div.foo to be removed
+        expect(astNode.childNodes[1].childNodes.length).toBe(0);
+        done();
+      });
+  });
+
+});
+

--- a/app-shell/src/app/shell-parser/node-visitor/template-strip-visitor.ts
+++ b/app-shell/src/app/shell-parser/node-visitor/template-strip-visitor.ts
@@ -1,0 +1,24 @@
+import {ASTNode} from '../ast';
+import {NodeVisitor} from './node-visitor';
+import {WorkerScope} from '../context';
+import {CssNodeMatcher} from '../node-matcher';
+
+export class TemplateStripVisitor extends NodeVisitor {
+
+  constructor(private matcher: CssNodeMatcher) {
+    super();
+  }
+
+  process(node: ASTNode) {
+    if (this.matcher.match(node)) {
+      if (node.parentNode) {
+        const c = node.parentNode.childNodes;
+        c.splice(c.indexOf(node), 1);
+      }
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(node);
+  }
+
+}
+

--- a/app-shell/src/app/shell-parser/shell-parser-factory.ts
+++ b/app-shell/src/app/shell-parser/shell-parser-factory.ts
@@ -1,6 +1,7 @@
 import {Parse5TemplateParser} from './template-parser';
 import {ShellParserImpl} from './shell-parser';
 import {cssNodeMatcherFactory} from './node-matcher';
+import {StylesheetResourceInlineVisitor, InlineStyleResourceInlineVisitor, TemplateStripVisitor, NodeVisitor} from './node-visitor';
 import {BrowserWorkerScope} from './context';
 import {ShellParserConfig, SHELL_PARSER_DEFAULT_CONFIG} from './config';
 
@@ -10,10 +11,17 @@ export const normalizeConfig = (config: ShellParserConfig) => {
 
 export const shellParserFactory = (config: ShellParserConfig = {}) => {
   const parserConfig = normalizeConfig(config);
+  const scope = new BrowserWorkerScope();
+  const visitors: NodeVisitor[] = [];
+  if (config.INLINE_IMAGES) {
+    visitors.push(new TemplateStripVisitor(cssNodeMatcherFactory(parserConfig.NO_RENDER_CSS_SELECTOR)));
+    visitors.push(new StylesheetResourceInlineVisitor(scope, config.INLINE_IMAGES));
+    visitors.push(new InlineStyleResourceInlineVisitor(scope, config.INLINE_IMAGES));
+  }
   return new ShellParserImpl(
       parserConfig,
       new Parse5TemplateParser(),
-      cssNodeMatcherFactory(parserConfig.NO_RENDER_CSS_SELECTOR),
-      new BrowserWorkerScope());
+      visitors,
+      scope);
 };
 

--- a/app-shell/src/app/shell-parser/shell-parser.spec.ts
+++ b/app-shell/src/app/shell-parser/shell-parser.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core/testing';
 import {BrowserWorkerScope, WorkerScope} from './context';
 import {ShellParserConfig, SHELL_PARSER_DEFAULT_CONFIG} from './config';
+import {TemplateStripVisitor} from './node-visitor';
 import {cssNodeMatcherFactory} from './node-matcher';
 import {Parse5TemplateParser} from './template-parser';
 import {normalizeConfig} from './shell-parser-factory';
@@ -91,7 +92,7 @@ const createMockedWorker = (mockScope: MockWorkerScope, config: ShellParserConfi
   return new ShellParserImpl(
       config,
       new Parse5TemplateParser(),
-      cssNodeMatcherFactory(config.NO_RENDER_CSS_SELECTOR),
+      [new TemplateStripVisitor(cssNodeMatcherFactory(config.NO_RENDER_CSS_SELECTOR))],
       mockScope);
 };
 

--- a/app-shell/src/app/shell-parser/testing/mock-requests.ts
+++ b/app-shell/src/app/shell-parser/testing/mock-requests.ts
@@ -4,7 +4,12 @@ export class MockBody {
   constructor(private _body: string) {}
 
   arrayBuffer(): Promise<any> {
-    throw 'Unimplemented';
+    var buf = new ArrayBuffer(this._body.length * 2);
+    var bufView = new Uint16Array(buf);
+    for (var i=0, strLen = this._body.length; i < strLen; i++) {
+      bufView[i] = this._body.charCodeAt(i);
+    }
+    return Promise.resolve(buf);
   }
 
   blob(): Promise<any> {

--- a/app-shell/src/system-config.ts
+++ b/app-shell/src/system-config.ts
@@ -27,6 +27,8 @@ const barrels: string[] = [
   'app/shared',
   'app/shell-parser',
   'app/shell-parser/template-parser',
+  'app/shell-parser/node-visitor',
+  'app/shell-parser/node-visitor/resource-inline',
   'app/shell-parser/node-matcher',
   'app/shell-parser/node-matcher/css-selector',
   'app/shell-parser/ast',


### PR DESCRIPTION
1. Allow visitors to process the AST produced by the template before serialization.
2. Implement inlining of external resources in stylesheets and style attributes.
3. Refactor the node stripping to use the visitors API.