### PR TITLE
Added Support for applicationServerKey in Push Subscribe

### DIFF
--- a/service-worker/worker/src/companion/comm.ts
+++ b/service-worker/worker/src/companion/comm.ts
@@ -112,7 +112,7 @@ export class NgServiceWorker {
         err => this.controllingWorker.error(err),
         () => this.controllingWorker.complete(),
       );
-    
+
     // To make one-off calls to the worker, awaitSingleControllingWorker waits for
     // a controlling worker to exist.
     this.awaitSingleControllingWorker = this
@@ -187,7 +187,7 @@ export class NgServiceWorker {
       // Wait for a controlling worker to exist.
       .awaitSingleControllingWorker
       // Send the message and await any replies. switchMap is chosen so if a new
-      // controlling worker arrives somehow, the message will still get through. 
+      // controlling worker arrives somehow, the message will still get through.
       .switchMap(worker => this.sendToWorker(worker, message));
   }
 
@@ -205,7 +205,7 @@ export class NgServiceWorker {
     });
   }
 
-  registerForPush(): Observable<NgPushRegistration> {
+  registerForPush(options?: PushSubscribeOptions): Observable<NgPushRegistration> {
     return this
       // Wait for a controlling worker to exist.
       .awaitSingleControllingWorker
@@ -229,9 +229,13 @@ export class NgServiceWorker {
               if (!!sub) {
                 return regFromSub(sub);
               }
-              // No existing subscription, register (with userVisibleOnly: true).
+              var ops: PushSubscribeOptions = {userVisibleOnly: true};
+              if (options) {
+                ops = options;
+              }
+              // No existing subscription, register (with user provided options or userVisibleOnly: true).
               return pushManager
-                .subscribe({userVisibleOnly: true})
+                .subscribe(ops)
                 .then(regFromSub);
             })
             // Map from promises to the Observable being returned.

--- a/service-worker/worker/src/typings/service-worker.d.ts
+++ b/service-worker/worker/src/typings/service-worker.d.ts
@@ -86,6 +86,7 @@ declare interface PushSubscription {
 
 declare interface PushSubscribeOptions {
   userVisibleOnly?: boolean;
+  applicationServerKey?: Uint8Array;
 }
 
 declare interface PushManager {


### PR DESCRIPTION
Fixes #121.

I'm not entirely sure that this is the best way to approach this. I'm not positive why the `userVisibleOnly` key was not configurable, but it's possible that this solution needs to be revised to not allow the user calling `registerForPush` to set it themselves.

Either way, review and let me know.