### PR TITLE
docs(worker): Fix webpack integration info

### DIFF
--- a/service-worker/worker/README.md
+++ b/service-worker/worker/README.md
@@ -213,7 +213,7 @@ If instead of Gulp, you use Webpack to build your project, the service worker al
 
     import {AngularServiceWorkerPlugin} from '@angular/service-worker/build/webpack';
     // or
-    const AngularServiceWorkerPlugin = require('@angular/service-worker/webpack');
+    const AngularServiceWorkerPlugin = require('@angular/service-worker/webpack').default;
     
     webpack({
       entry: 'index.js',
@@ -227,6 +227,6 @@ If instead of Gulp, you use Webpack to build your project, the service worker al
         new CopyWebpackPlugin([
           {from: 'ngsw-manifest.json'},
         ]),
-        new AngularServiceWorkerPlugion(),
+        new AngularServiceWorkerPlugin(),
       ],
     }, () => { /* done */ });


### PR DESCRIPTION
I have noticed the AngularServiceWorkerPlugin is exported as default so to get a reference to the plugin one should be using : 

```
const AngularServiceWorkerPlugin = require('@angular/service-worker/webpack').default;
```

Also fixing a little typo when calling the plugin "Plugion" to "Plugin"