### PR TITLE
fix(worker): correctly emit falsy values sent by the ServiceWorker

### DIFF
--- a/service-worker/worker/src/companion/comm.ts
+++ b/service-worker/worker/src/companion/comm.ts
@@ -31,7 +31,6 @@ import 'rxjs/add/operator/reduce';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/take';
-import 'rxjs/add/operator/takeWhile';
 
 function fromPromise<T>(promiseFn: (() => Promise<T>)): Observable<T> {
   return Observable.create(observer => {
@@ -119,7 +118,7 @@ export class NgServiceWorker {
         err => this.controllingWorker.error(err),
         () => this.controllingWorker.complete(),
       );
-    
+
     // To make one-off calls to the worker, awaitSingleControllingWorker waits for
     // a controlling worker to exist.
     this.awaitSingleControllingWorker = this
@@ -172,8 +171,6 @@ export class NgServiceWorker {
           this.sendToWorker(worker, {cmd: 'cancel', id: cancelId});
         };
       })
-      // Instead of complicating this with 'close' events, complete on a null value.
-      .takeWhile(v => !!v)
       // The message will be sent before the consumer has a chance to subscribe to
       // the response Observable, so publishReplay() records any responses and ensures
       // they arrive properly.
@@ -199,7 +196,7 @@ export class NgServiceWorker {
       // Wait for a controlling worker to exist.
       .awaitSingleControllingWorker
       // Send the message and await any replies. switchMap is chosen so if a new
-      // controlling worker arrives somehow, the message will still get through. 
+      // controlling worker arrives somehow, the message will still get through.
       .switchMap(worker => this.sendToWorker(worker, message));
   }
 


### PR DESCRIPTION
Currently, there is check that completes the observable on falsy values (`takeWhile(v => !!v)`). This was first introduced in [ffea4acfe][1], when there was no other mechanism for completing the observable (and possibly all sent values were objects). Then a different mechanism was introduced in [563e7ac44][2], with a stricter check (`data === null`).

Since there are types of messages that send boolean values (e.g. [`checkForUpdate`][3] or [`activateUpdate`][4]), it is necessary to not complete the observable on `false`.

[1]: https://github.com/angular/mobile-toolkit/commit/ffea4acfe442da3af7050c37b0d7baf005efe834#diff-a223d9a67ca2c0a46e98a4f481f74944R133
[2]: https://github.com/angular/mobile-toolkit/commit/563e7ac4424e823bbde0867c7dbb527ea206d326#diff-a223d9a67ca2c0a46e98a4f481f74944R148
[3]: https://github.com/angular/mobile-toolkit/blob/f9d83026ea75af1f3a2848903e4072bce19cb5e9/service-worker/worker/src/worker/driver.ts#L850
[4]: https://github.com/angular/mobile-toolkit/blob/f9d83026ea75af1f3a2848903e4072bce19cb5e9/service-worker/worker/src/worker/driver.ts#L856