### PR TITLE
fix(worker): manually follow redirects in static content caching

### DIFF
--- a/service-worker/worker/src/test/e2e/harness/server/server.ts
+++ b/service-worker/worker/src/test/e2e/harness/server/server.ts
@@ -21,6 +21,9 @@ export class Server {
     this.app = express();
     this.app.use(express.static(harnessPath));
     this.server = this.app.listen(port, () => readyCallback());
+    this.app.get('/index2.html', (req, resp) => {
+      resp.redirect(301, '/index.html');
+    });
     this.app.post('/ngsw-log', (req, resp) => {
       let content = '';
       req.on('data', data => content += data);

--- a/service-worker/worker/src/test/e2e/spec/sanity.e2e.ts
+++ b/service-worker/worker/src/test/e2e/spec/sanity.e2e.ts
@@ -41,6 +41,7 @@ const FORCED_UPDATE_MANIFEST = {
     urls: {
       '/hello.txt': 'changed_again',
       '/goodbye.txt': 'same',
+      '/index2.html': 'added'
     },
   },
   dynamic: {
@@ -265,7 +266,13 @@ describe('world sanity', () => {
       .then(() => po.request('/fresh/test'))
       .then(result => expect(result).toBe('Delayed long'))
       .then(() => done());
-  })
+  });
+  it('reloads from /index2.html without failure', done => {
+    browser
+      .get('http://localhost:8080/index2.html')
+      .then(() => po.ping())
+      .then(() => done());
+  });
 });
 
 function wait(delayMs: number): Promise<void> {


### PR DESCRIPTION
Before this change, static content caching would fetch all the URLs
described in the manifest directly, and accept whatever response came back.

If, though, a server was configured to redirect one of the static URLs (for
example, Firebase 301 redirects /index.html to /), the response would be
cached as a 200 with the Response.redirected flag set to true. It is illegal
per the SW spec to respond to a navigation request with such a redirected
Response, and this breaks in Chrome 59 and higher.

With this change, static content caching now looks at Response.redirected
and if the flag is set, it requests Response.url directly to obtain a
Response which was not redirected.

An e2e test verifies that such a redirected static URL still works as a
navigation request.